### PR TITLE
feat: Rename project to mcp-shopline and add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build dependencies
+        run: pip install build
+      - name: Build package
+        run: python -m build
+      - name: Store distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mcp-shopline
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ __pycache__/
 *.tmp
 .venv/
 venv/
+dist/
+*.egg-info
+.claude/*.md
+.claude/*.local.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Shopline API MCP Server
+# Contributing to MCP Shopline
 
 Thank you for your interest in contributing! This guide will help you get started.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Shopline API MCP Server
+# MCP Shopline
 
 [繁體中文](README.zh-TW.md)
 
@@ -31,8 +31,8 @@ You need a valid Shopline API access token from a Shopline merchant account. Ref
 ### 1. Clone and Configure
 
 ```bash
-git clone https://github.com/asgard-ai-platform/shopline-api-mcp-server.git
-cd shopline-api-mcp-server
+git clone https://github.com/asgard-ai-platform/mcp-shopline.git
+cd mcp-shopline
 
 cp .env.example .env
 # Edit .env with your Shopline API access token

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,4 +1,4 @@
-# Shopline API MCP Server
+# MCP Shopline
 
 開源的 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) 伺服器，將 [Shopline Open API](https://open-api.docs.shoplineapp.com/docs/getting-started) 封裝為 19 個 AI 可調用的電商數據分析工具。
 
@@ -29,8 +29,8 @@
 ### 1. 下載與設定
 
 ```bash
-git clone https://github.com/asgard-ai-platform/shopline-api-mcp-server.git
-cd shopline-api-mcp-server
+git clone https://github.com/asgard-ai-platform/mcp-shopline.git
+cd mcp-shopline
 
 cp .env.example .env
 # 編輯 .env，填入您的 Shopline API Access Token
@@ -127,7 +127,7 @@ python tests/test_all_tools.py
 ## 專案結構
 
 ```
-shopline-api-mcp-server/
+mcp-shopline/
 ├── mcp_server.py              # MCP 伺服器（stdio JSON-RPC 2.0）
 ├── .mcp.json                  # Claude Code MCP 自動偵測設定
 ├── .env.example               # 環境變數範本

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -19,8 +19,8 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from tools.tool_registry import get_tool_schemas, execute_tool
 
 
-SERVER_NAME = "shopline-api-tools"
-SERVER_VERSION = "1.0.0"
+SERVER_NAME = "mcp-shopline"
+SERVER_VERSION = "0.1.0"
 PROTOCOL_VERSION = "2024-11-05"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "shopline-api-mcp-server"
+name = "mcp-shopline"
 version = "0.1.0"
 description = "MCP server wrapping the Shopline Open API into 19 AI Agent-callable tools for e-commerce data analysis"
 readme = "README.md"
@@ -12,7 +12,6 @@ keywords = ["mcp", "shopline", "e-commerce", "ai-agent", "claude"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -25,13 +24,19 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/asgard-ai-platform/shopline-api-mcp-server"
-Repository = "https://github.com/asgard-ai-platform/shopline-api-mcp-server"
-Issues = "https://github.com/asgard-ai-platform/shopline-api-mcp-server/issues"
+Homepage = "https://github.com/asgard-ai-platform/mcp-shopline"
+Repository = "https://github.com/asgard-ai-platform/mcp-shopline"
+Issues = "https://github.com/asgard-ai-platform/mcp-shopline/issues"
 
 [build-system]
 requires = ["setuptools>=68.0"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
+
+[project.scripts]
+shopline-mcp = "mcp_server:main"
+
+[tool.setuptools]
+py-modules = ["mcp_server"]
 
 [tool.setuptools.packages.find]
 include = ["config*", "tools*"]


### PR DESCRIPTION
Rename all references from shopline-api-mcp-server to mcp-shopline to match the actual GitHub repository name. Add GitHub Actions workflow for publishing to PyPI via trusted OIDC publishing.